### PR TITLE
Update jdbc driver and workflows

### DIFF
--- a/.github/workflows/go-driver.yml
+++ b/.github/workflows/go-driver.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         go-version: [ '1.18', '1.19' ]
-        distributions: ['zulu', 'temurin', 'microsoft']
+
     defaults:
       run:
         working-directory: drivers/golang/age/
@@ -46,12 +46,6 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
-    
-    - name: Set up Java
-      uses: actions/setup-java@v3
-      with:
-        distribution: ${{ matrix.distributions }}
-        java-version: '17'
     
     - name: Generate
       run: go generate ./../...

--- a/.github/workflows/jdbc-driver.yaml
+++ b/.github/workflows/jdbc-driver.yaml
@@ -10,22 +10,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
-    strategy:
-      matrix:
-        distributions: ['zulu', 'temurin', 'microsoft']
-
+        
     defaults:
       run:
         working-directory: drivers/jdbc
 
     steps:
     - uses: actions/checkout@v3
-
+    
     - name: Set up Java
       uses: actions/setup-java@v3
       with:
-        distribution: ${{ matrix.distributions }}
+        distribution: 'zulu'
         java-version: '17'
 
     - name: Set tag based on branch

--- a/drivers/jdbc/lib/build.gradle.kts
+++ b/drivers/jdbc/lib/build.gradle.kts
@@ -30,18 +30,18 @@ repositories {
 }
 
 dependencies {
-    implementation("org.postgresql:postgresql:42.2.20")
-    api("org.apache.commons:commons-text:1.9")
-    antlr("org.antlr:antlr4:4.9.2")
+    implementation("org.postgresql:postgresql:42.6.0")
+    api("org.apache.commons:commons-text:1.10.0")
+    antlr("org.antlr:antlr4:4.12.0")
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.3")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 
-    testImplementation("org.testcontainers:testcontainers:1.15.3")
-    testImplementation("org.postgresql:postgresql:42.2.20")
+    testImplementation("org.testcontainers:testcontainers:1.18.0")
+    testImplementation("org.postgresql:postgresql:42.6.0")
 
-    testImplementation("org.slf4j:slf4j-api:1.7.5")
-    testImplementation("org.slf4j:slf4j-simple:1.7.5")
+    testImplementation("org.slf4j:slf4j-api:2.0.7")
+    testImplementation("org.slf4j:slf4j-simple:2.0.7")
 }
 
 tasks.generateGrammarSource {

--- a/drivers/jdbc/lib/src/test/java/org/apache/age/jdbc/AgtypeStatementTest.java
+++ b/drivers/jdbc/lib/src/test/java/org/apache/age/jdbc/AgtypeStatementTest.java
@@ -29,11 +29,14 @@ import java.sql.Statement;
 import org.apache.age.jdbc.base.Agtype;
 import org.apache.age.jdbc.base.AgtypeFactory;
 import org.apache.age.jdbc.base.InvalidAgtypeException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.postgresql.jdbc.PgConnection;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 
+@TestInstance(Lifecycle.PER_CLASS)
 /**
  * Tests the different combinations that are possible when running Statements and Prepared
  * Statements with the AgType and shows how the JDBC needs to be setup to convert values to the
@@ -43,12 +46,12 @@ class AgtypeStatementTest {
 
     BaseDockerizedTest baseDockerizedTest = new BaseDockerizedTest();
 
-    @BeforeEach
+    @BeforeAll
     public void setup() throws Exception {
         baseDockerizedTest.beforeAll();
     }
 
-    @AfterEach
+    @AfterAll
     void tearDown() throws Exception {
         baseDockerizedTest.afterAll();
     }

--- a/drivers/jdbc/lib/src/test/java/org/apache/age/jdbc/BaseDockerizedTest.java
+++ b/drivers/jdbc/lib/src/test/java/org/apache/age/jdbc/BaseDockerizedTest.java
@@ -65,9 +65,13 @@ public class BaseDockerizedTest {
         String jdbcUrl = String
             .format("jdbc:postgresql://%s:%d/%s", "localhost", mappedPort, "postgres");
 
-        connection = DriverManager.getConnection(jdbcUrl, "postgres", CORRECT_DB_PASSWORDS)
-            .unwrap(PgConnection.class);
-        connection.addDataType("agtype", Agtype.class);
+        try {
+            this.connection = DriverManager.getConnection(jdbcUrl, "postgres", CORRECT_DB_PASSWORDS)
+                         .unwrap(PgConnection.class);
+            this.connection.addDataType("agtype", Agtype.class);
+        } catch (Exception e) {
+            System.out.println(e);
+        }
         try (Statement statement = connection.createStatement()) {
             statement.execute("CREATE EXTENSION IF NOT EXISTS age;");
             statement.execute("LOAD 'age'");


### PR DESCRIPTION
- Update jdbc and go driver workflows
  - Removed reduntant setup for java environment in go driver workflow.
  - Removed builds for microsoft and tumerin distros from jdbc driver
    workflow.

- Update jdbc driver dependencies and tests
  - Updated jdbc dependencies to latest.
  - Changed AgtypeStatementTest to create connection one time for all
    tests in this class instead of making and breaking connection for
    each test. 'beforeEach' and 'afterEach' was resulting in connection
    failure occasionaly.