### PR TITLE
Add auto apply labeler workflow for PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,17 @@
+PG11:
+- base-branch: 'PG11'
+
+PG12:
+- base-branch: 'PG12'
+
+PG13:
+- base-branch: 'PG13'
+
+PG14:
+- base-branch: 'PG14'
+
+PG15:
+- base-branch: 'PG15'
+
+master:
+- base-branch: 'master'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4


### PR DESCRIPTION
- This will help us to filter out PRs intended for a specific branch e.g PG11, PG12, PG13, PG14, PG15, master and any PR for other ongoing project branches.

- Currently it supports only PG11, PG12, PG13, PG14, PG15 and master. We can add more by adding a new entry in the .github/labeler.yml file.